### PR TITLE
OpenSearch support

### DIFF
--- a/py_conf_mcp/tools/sources/web_api.py
+++ b/py_conf_mcp/tools/sources/web_api.py
@@ -56,13 +56,14 @@ def get_requests_auth(
     )
 
 
-class WebApiTool(ToolClass):
+class WebApiTool(ToolClass):  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
         url: str,
         *,
         query_parameters: Optional[Mapping[str, str]] = None,
         json_template: Optional[str] = None,
+        response_template: Optional[str] = None,
         headers: Optional[Mapping[str, str]] = None,
         method: str = 'GET',
         verify_ssl: bool = True,
@@ -72,6 +73,7 @@ class WebApiTool(ToolClass):
         self.url = url
         self.query_parameters = query_parameters or {}
         self.json_template = json_template
+        self.response_template = response_template
         self.method = method
         self.verify_ssl = verify_ssl
         self.headers = headers
@@ -104,5 +106,15 @@ class WebApiTool(ToolClass):
         )
         response.raise_for_status()
         response_json = response.json()
-        LOGGER.info('response_json: %r', response_json)
-        return response_json
+        if not self.response_template:
+            LOGGER.info('response_json: %r', response_json)
+            return response_json
+        response_content = get_evaluated_template(
+            self.response_template,
+            variables={
+                'response_json': response_json,
+                'params': params
+            }
+        )
+        LOGGER.info('response_content after template: %r', response_content)
+        return response_content

--- a/py_conf_mcp/tools/sources/web_api.py
+++ b/py_conf_mcp/tools/sources/web_api.py
@@ -30,17 +30,20 @@ def get_evaluated_query_parameters(
 
 
 class WebApiTool(ToolClass):
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         url: str,
+        *,
         query_parameters: Optional[Mapping[str, str]] = None,
         headers: Optional[Mapping[str, str]] = None,
-        method: str = 'GET'
+        method: str = 'GET',
+        verify_ssl: bool = True
     ):
         super().__init__()
         self.url = url
         self.query_parameters = query_parameters or {}
         self.method = method
+        self.verify_ssl = verify_ssl
         self.headers = headers
 
     def __call__(self, **kwargs):
@@ -58,7 +61,8 @@ class WebApiTool(ToolClass):
             method=self.method,
             url=url,
             params=params,
-            headers=self.headers
+            headers=self.headers,
+            verify=self.verify_ssl
         )
         response.raise_for_status()
         response_json = response.json()

--- a/py_conf_mcp/tools/sources/web_api.py
+++ b/py_conf_mcp/tools/sources/web_api.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Any, Mapping, Optional, TypedDict
 
 import jinja2
@@ -17,8 +18,14 @@ def get_requests_session() -> requests.Session:
     return requests.Session()
 
 
+def read_secret_from_env(var_name: str) -> str:
+    path = os.environ[var_name]
+    return Path(path).read_text(encoding='utf-8')
+
+
 def get_evaluated_template(template: str, variables: Mapping[str, Any]) -> Any:
     compiled_template = jinja2.Template(template)
+    compiled_template.globals['read_secret_from_env'] = read_secret_from_env
     return compiled_template.render(variables)
 
 

--- a/py_conf_mcp/tools/sources/web_api.py
+++ b/py_conf_mcp/tools/sources/web_api.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from typing import Any, Mapping, Optional, TypedDict
 
 import jinja2
@@ -50,9 +51,18 @@ def get_requests_auth(
 ) -> Optional[requests.auth.HTTPBasicAuth]:
     if not basic_auth:
         return None
+    variables = {
+        'env': os.environ
+    }
     return requests.auth.HTTPBasicAuth(
-        username=basic_auth['username'],
-        password=basic_auth['password']
+        username=get_evaluated_template(
+            basic_auth['username'],
+            variables=variables
+        ),
+        password=get_evaluated_template(
+            basic_auth['password'],
+            variables=variables
+        )
     )
 
 

--- a/py_conf_mcp/tools/sources/web_api.py
+++ b/py_conf_mcp/tools/sources/web_api.py
@@ -90,8 +90,9 @@ class WebApiTool(ToolClass):
         )
         LOGGER.info(
             'url: %r (method: %r, params: %r, kwargs: %r, has_json_body: %r)',
-            url, self.method, params, kwargs, bool(self.json_template)
+            url, self.method, params, kwargs, bool(json_body)
         )
+        LOGGER.info('json_body: %r', json_body)
         response = session.request(
             method=self.method,
             url=url,

--- a/tests/unit_tests/tools/sources/web_api_test.py
+++ b/tests/unit_tests/tools/sources/web_api_test.py
@@ -54,7 +54,8 @@ class TestWebApiTool:
             method='POST',
             url=URL_1,
             params=ANY,
-            headers=HEADERS_1
+            headers=HEADERS_1,
+            verify=ANY
         )
 
     def test_should_return_response_from_api(self, requests_response_mock: MagicMock):
@@ -75,7 +76,8 @@ class TestWebApiTool:
             method='GET',
             url=r'https://example/url_1?param_1=value_1',
             params=ANY,
-            headers=ANY
+            headers=ANY,
+            verify=ANY
         )
 
     def test_should_replace_placeholders_in_query_parameters(
@@ -93,5 +95,6 @@ class TestWebApiTool:
             method='GET',
             url=r'https://example/url_1',
             params={'param_1': 'value_1'},
-            headers=ANY
+            headers=ANY,
+            verify=ANY
         )

--- a/tests/unit_tests/tools/sources/web_api_test.py
+++ b/tests/unit_tests/tools/sources/web_api_test.py
@@ -52,6 +52,21 @@ class TestGetRequestsAuth:
         assert auth.username == 'user'
         assert auth.password == 'pass'
 
+    def test_should_return_http_basic_auth_from_env_var(
+        self,
+        mock_env: dict[str, str]
+    ):
+        mock_env['BASIC_AUTH_USERNAME'] = 'user'
+        mock_env['BASIC_AUTH_PASSWORD'] = 'pass'
+        basic_auth: BasicAuthConfig = {
+            'username': '{{ env.BASIC_AUTH_USERNAME }}',
+            'password': '{{ env.BASIC_AUTH_PASSWORD }}'
+        }
+        auth = web_api.get_requests_auth(basic_auth)
+        assert isinstance(auth, requests.auth.HTTPBasicAuth)
+        assert auth.username == 'user'
+        assert auth.password == 'pass'
+
 
 class TestWebApiTool:
     def test_should_pass_method_url_and_headers_to_api(

--- a/tests/unit_tests/tools/sources/web_api_test.py
+++ b/tests/unit_tests/tools/sources/web_api_test.py
@@ -1,3 +1,4 @@
+import json
 from typing import Iterator
 from unittest.mock import ANY, MagicMock, patch
 
@@ -56,7 +57,8 @@ class TestWebApiTool:
             params=ANY,
             headers=HEADERS_1,
             auth=ANY,
-            verify=ANY
+            verify=ANY,
+            json=ANY
         )
 
     def test_should_return_response_from_api(self, requests_response_mock: MagicMock):
@@ -79,7 +81,8 @@ class TestWebApiTool:
             params=ANY,
             headers=ANY,
             auth=ANY,
-            verify=ANY
+            verify=ANY,
+            json=ANY
         )
 
     def test_should_replace_placeholders_in_query_parameters(
@@ -99,5 +102,6 @@ class TestWebApiTool:
             params={'param_1': 'value_1'},
             headers=ANY,
             auth=ANY,
-            verify=ANY
+            verify=ANY,
+            json=ANY
         )

--- a/tests/unit_tests/tools/sources/web_api_test.py
+++ b/tests/unit_tests/tools/sources/web_api_test.py
@@ -3,9 +3,10 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 import requests
+import requests.auth
 
 from py_conf_mcp.tools.sources import web_api
-from py_conf_mcp.tools.sources.web_api import WebApiTool
+from py_conf_mcp.tools.sources.web_api import BasicAuthConfig, WebApiTool
 
 
 URL_1 = 'https://example/url_1'
@@ -36,7 +37,20 @@ def _requests_request_fn_mock(requests_session_mock: MagicMock) -> MagicMock:
 def _requests_mock(requests_session_mock: MagicMock) -> Iterator[MagicMock]:
     with patch.object(web_api, 'requests') as mock:
         mock.Session.return_value = requests_session_mock
+        mock.auth = requests.auth
         yield mock
+
+
+class TestGetRequestsAuth:
+    def test_should_return_none_if_no_basic_auth(self):
+        assert web_api.get_requests_auth(None) is None
+
+    def test_should_return_http_basic_auth_from_values(self):
+        basic_auth: BasicAuthConfig = {'username': 'user', 'password': 'pass'}
+        auth = web_api.get_requests_auth(basic_auth)
+        assert isinstance(auth, requests.auth.HTTPBasicAuth)
+        assert auth.username == 'user'
+        assert auth.password == 'pass'
 
 
 class TestWebApiTool:

--- a/tests/unit_tests/tools/sources/web_api_test.py
+++ b/tests/unit_tests/tools/sources/web_api_test.py
@@ -1,4 +1,3 @@
-import json
 from typing import Iterator
 from unittest.mock import ANY, MagicMock, patch
 

--- a/tests/unit_tests/tools/sources/web_api_test.py
+++ b/tests/unit_tests/tools/sources/web_api_test.py
@@ -55,6 +55,7 @@ class TestWebApiTool:
             url=URL_1,
             params=ANY,
             headers=HEADERS_1,
+            auth=ANY,
             verify=ANY
         )
 
@@ -77,6 +78,7 @@ class TestWebApiTool:
             url=r'https://example/url_1?param_1=value_1',
             params=ANY,
             headers=ANY,
+            auth=ANY,
             verify=ANY
         )
 
@@ -96,5 +98,6 @@ class TestWebApiTool:
             url=r'https://example/url_1',
             params={'param_1': 'value_1'},
             headers=ANY,
+            auth=ANY,
             verify=ANY
         )


### PR DESCRIPTION
OpenSearch support is enabled by:

- disabling SSL verification (depending on how OpenSearch was enabled)
- secrets from env file name
- post body template to send query
- response body to better extract information from the response